### PR TITLE
Added margin-right for space between select & button

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -65,8 +65,7 @@ select, button {
 }
 
 button {
-    margin-top: 20px;
-    margin-bottom: 20px;
+    margin: 20px 0px 20px 40px; /* top right bottom left */
     transition: color 0.4s, background-color 0.4s;
 }
 


### PR DESCRIPTION
- updated CSS
- condensed margin property under line 67 button 
- added a 40px margin right to the margin property 
- what it does is add space between the select option and the button on the homepage, while keeping the select and button HTML elements centered on the page 